### PR TITLE
Update teamspeak and reduce container size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,22 @@ FROM orimani/alpine-glibc
 
 MAINTAINER Mat <mat@orimani.info>
 
-ENV TS_URL http://dl.4players.de/ts/releases/3.0.11.4/teamspeak3-server_linux-amd64-3.0.11.4.tar.gz
-
-RUN apk --update add curl \
-&& curl -L $TS_URL -o /tmp/teamspeak.tar.gz \
-&& mkdir /opt \
-&& tar zxf /tmp/teamspeak.tar.gz -C /opt \
-&& mv /opt/teamspeak3-server_* /opt/teamspeak \
-&& addgroup -g 503 teamspeak \
-&& adduser -u 503 -G teamspeak -h /opt/teamspeak -S -D teamspeak \
-&& chown -R teamspeak:teamspeak /opt/teamspeak \
-&& apk del curl \
-&& rm -rf \
-   /tmp/teamspeak.tar.gz \
-   /var/cache/apk*
+RUN export \
+    TS_CHECKSUM="51eff1023549140fec592cb140edb0670c11cbf9" \
+    TS_URL="http://dl.4players.de/ts/releases/3.0.12.2/teamspeak3-server_linux_amd64-3.0.12.2.tar.bz2" \
+ && apk --update add curl \
+ && curl -L $TS_URL -o /tmp/teamspeak.tar.bz2 \
+ && if [ $(sha1sum /tmp/teamspeak.tar.bz2 | awk {'print $1'}) != $TS_CHECKSUM ]; then echo "CHECKSUM CHECK FAILED: teamspeak"; exit 1; fi \
+ && mkdir /opt \
+ && tar xjf /tmp/teamspeak.tar.bz2 -C /opt \
+ && mv /opt/teamspeak3-server_* /opt/teamspeak \
+ && addgroup -g 503 teamspeak \
+ && adduser -u 503 -G teamspeak -h /opt/teamspeak -S -D teamspeak \
+ && chown -R teamspeak:teamspeak /opt/teamspeak \
+ && apk del curl \
+ && rm -rf \
+    /tmp/teamspeak.tar.bz2 \
+    /var/cache/apk*
 
 EXPOSE 9987/udp 10011 30033
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,20 @@ FROM orimani/alpine-glibc
 
 MAINTAINER Mat <mat@orimani.info>
 
-ADD http://dl.4players.de/ts/releases/3.0.11.4/teamspeak3-server_linux-amd64-3.0.11.4.tar.gz /tmp/teamspeak.tar.gz
+ENV TS_URL http://dl.4players.de/ts/releases/3.0.11.4/teamspeak3-server_linux-amd64-3.0.11.4.tar.gz
 
-RUN mkdir /opt && \
-  tar zxf /tmp/teamspeak.tar.gz -C /opt && \
-  mv /opt/teamspeak3-server_* /opt/teamspeak && \
-  rm /tmp/teamspeak.tar.gz && \
-  addgroup -g 503 teamspeak && \
-  adduser -u 503 -G teamspeak -h /opt/teamspeak -S -D teamspeak && \
-  chown -R teamspeak:teamspeak /opt/teamspeak
+RUN apk --update add curl \
+&& curl -L $TS_URL -o /tmp/teamspeak.tar.gz \
+&& mkdir /opt \
+&& tar zxf /tmp/teamspeak.tar.gz -C /opt \
+&& mv /opt/teamspeak3-server_* /opt/teamspeak \
+&& addgroup -g 503 teamspeak \
+&& adduser -u 503 -G teamspeak -h /opt/teamspeak -S -D teamspeak \
+&& chown -R teamspeak:teamspeak /opt/teamspeak \
+&& apk del curl \
+&& rm -rf \
+   /tmp/teamspeak.tar.gz \
+   /var/cache/apk*
 
 EXPOSE 9987/udp 10011 30033
 


### PR DESCRIPTION
Hi,

I've just updated to the most actual TS3-Version and also reduced the container size to 25.38 MB (although the new TS version is > 2 MB bigger than the previous used one).

Would you like to merge this pull-request?